### PR TITLE
Fix an issue where #mainItems would not disappead even when menu was closed

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -54,7 +54,7 @@
 
 	    paper-fab-menu[position="horizontal"] {
 	    	position: absolute;
-	    	right: 185px;
+	    	right: 20px;
 	    	bottom: 20px;
 	    }
 
@@ -181,7 +181,7 @@
 			<a target="_blank" href="http://spacee.xyz">
 				<paper-fab-menu-item label="Favorites" icon="star" ></paper-fab-menu-item>
 			</a>
-			<a target="_blank" href="http://spacee.xyz">	
+			<a target="_blank" href="http://spacee.xyz">
 				<paper-fab-menu-item label="Refresh" icon="refresh" ></paper-fab-menu-item>
 			</a>
 	  	</paper-fab-menu>

--- a/demo.html
+++ b/demo.html
@@ -68,8 +68,7 @@
 	    	margin: 30px -230px;
 	    }
 
-		pre
-		{
+		pre {
 			width: 100%;
 		}
 
@@ -82,17 +81,17 @@
 		<div class="code-area">
 			<pre>
 				&#x3C;paper-fab-menu icon=&#x22;add&#x22; position=&#x22;vertical&#x22;&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x3C;/paper-fab-menu&#x3E;
 			</pre>
 		</div>
 
 		<paper-fab-menu icon="add" position="vertical">
-			<paper-fab-menu-item label="Polymer" icon="polymer" ></paper-fab-menu-item>
-			<paper-fab-menu-item label="Favorites" icon="star" ></paper-fab-menu-item>
-			<paper-fab-menu-item label="Refresh" icon="refresh" ></paper-fab-menu-item>
+			<paper-fab-menu-item label="Polymer" icon="polymer"></paper-fab-menu-item>
+			<paper-fab-menu-item label="Favorites" icon="star"></paper-fab-menu-item>
+			<paper-fab-menu-item label="Refresh" icon="refresh"></paper-fab-menu-item>
 	  	</paper-fab-menu>
 	</paper-material>
 
@@ -101,17 +100,17 @@
 		<div class="code-area">
 			<pre>
 				&#x3C;paper-fab-menu icon=&#x22;add&#x22; position=&#x22;vertical reversed&#x22;&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x3C;/paper-fab-menu&#x3E;
 			</pre>
 		</div>
 
 		<paper-fab-menu icon="add" position="vertical reversed">
-			<paper-fab-menu-item label="Polymer" icon="polymer" ></paper-fab-menu-item>
-			<paper-fab-menu-item label="Favorites" icon="star" ></paper-fab-menu-item>
-			<paper-fab-menu-item label="Refresh" icon="refresh" ></paper-fab-menu-item>
+			<paper-fab-menu-item label="Polymer" icon="polymer"></paper-fab-menu-item>
+			<paper-fab-menu-item label="Favorites" icon="star"></paper-fab-menu-item>
+			<paper-fab-menu-item label="Refresh" icon="refresh"></paper-fab-menu-item>
 	  	</paper-fab-menu>
 	</paper-material>
 
@@ -120,18 +119,18 @@
 		<div class="code-area">
 			<pre>
 				&#x3C;paper-fab-menu color="#2196F3" icon=&#x22;add&#x22; position=&#x22;horizontal&#x22;&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Favorites&#x22; icon=&#x22;star&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Favorites&#x22; icon=&#x22;star&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x3C;/paper-fab-menu&#x3E;
 			</pre>
 		</div>
 
 
   		<paper-fab-menu color="#2196F3" icon="add" position="horizontal">
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Polymer" icon="polymer" ></paper-fab-menu-item>
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Favorites" icon="star" ></paper-fab-menu-item>
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Refresh" icon="refresh" ></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Polymer" icon="polymer"></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Favorites" icon="star"></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Refresh" icon="refresh"></paper-fab-menu-item>
 	  	</paper-fab-menu>
 	</paper-material>
 
@@ -140,18 +139,18 @@
 		<div class="code-area">
 			<pre>
 				&#x3C;paper-fab-menu color="#2196F3" icon=&#x22;add&#x22; position=&#x22;horizontal reversed&#x22;&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Favorites&#x22; icon=&#x22;star&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
-				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Favorites&#x22; icon=&#x22;star&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x3C;paper-fab-menu-item tooltip-position="top" color="#2196F3" label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x3C;/paper-fab-menu&#x3E;
 			</pre>
 		</div>
 
 
   		<paper-fab-menu color="#2196F3" icon="add" position="horizontal reversed">
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Polymer" icon="polymer" ></paper-fab-menu-item>
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Favorites" icon="star" ></paper-fab-menu-item>
-			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Refresh" icon="refresh" ></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Polymer" icon="polymer"></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Favorites" icon="star"></paper-fab-menu-item>
+			<paper-fab-menu-item tooltip-position="top" color="#2196F3" label="Refresh" icon="refresh"></paper-fab-menu-item>
 	  	</paper-fab-menu>
 	</paper-material>
 
@@ -161,13 +160,13 @@
 			<pre>
 				&#x3C;paper-fab-menu icon=&#x22;add&#x22; position=&#x22;vertical&#x22;&#x3E;
 				&#x9;&#x3C;a target=&#x22;_blank&#x22; href=&#x22;http://spacee.xyz&#x22;&#x3E;
-				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Polymer&#x22; icon=&#x22;polymer&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x9;&#x3C;/a&#x3E;
 				&#x9;&#x3C;a target=&#x22;_blank&#x22; href=&#x22;http://spacee.xyz&#x22;&#x3E;
-				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Favorites&#x22; icon=&#x22;star&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x9;&#x3C;/a&#x3E;
 				&#x9;&#x3C;a target=&#x22;_blank&#x22; href=&#x22;http://spacee.xyz&#x22;&#x3E;&#x9;
-				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22; &#x3E;&#x3C;/paper-fab-menu-item&#x3E;
+				&#x9;&#x9;&#x3C;paper-fab-menu-item label=&#x22;Refresh&#x22; icon=&#x22;refresh&#x22;&#x3E;&#x3C;/paper-fab-menu-item&#x3E;
 				&#x9;&#x3C;/a&#x3E;
 				&#x3C;/paper-fab-menu&#x3E;
 			</pre>
@@ -176,13 +175,13 @@
 
   		<paper-fab-menu icon="add" position="vertical">
   			<a target="_blank" href="http://spacee.xyz">
-				<paper-fab-menu-item label="Polymer" icon="polymer" ></paper-fab-menu-item>
+				<paper-fab-menu-item label="Polymer" icon="polymer"></paper-fab-menu-item>
 			</a>
 			<a target="_blank" href="http://spacee.xyz">
-				<paper-fab-menu-item label="Favorites" icon="star" ></paper-fab-menu-item>
+				<paper-fab-menu-item label="Favorites" icon="star"></paper-fab-menu-item>
 			</a>
 			<a target="_blank" href="http://spacee.xyz">
-				<paper-fab-menu-item label="Refresh" icon="refresh" ></paper-fab-menu-item>
+				<paper-fab-menu-item label="Refresh" icon="refresh"></paper-fab-menu-item>
 			</a>
 	  	</paper-fab-menu>
 	</paper-material>

--- a/paper-fab-menu-item.html
+++ b/paper-fab-menu-item.html
@@ -2,12 +2,12 @@
     <template>
         <style is="custom-style">
             :host .menu-item {
-                position : relative;
+                position: relative;
             }
 
             :host {
-                flex   : 1;
-                margin : 7px;
+                flex: 1;
+                margin: 7px;
             }
 
             :host .menu-item paper-fab ::content iron-icon {
@@ -15,7 +15,7 @@
             }
 
             :host .menu-item {
-                transform  : scale(0);
+                transform: scale(0);
             }
         </style>
         <div class="menu-item">
@@ -25,17 +25,17 @@
     </template>
     <script>
         Polymer({
-            is         : 'paper-fab-menu-item',
-            properties : {
-                color : {
-                    type : 'String'
+            is: 'paper-fab-menu-item',
+            properties: {
+                color: {
+                    type: 'String'
                 },
                 tooltipPosition: {
                     type: 'String',
                     value: 'left'
                 }
             },
-            ready      : function() {
+            ready: function() {
                 if(this.color)
                     this.$.paperFab.style.backgroundColor = this.color;
             }

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -44,11 +44,9 @@
 <dom-module id="paper-fab-menu">
     <style is="custom-style">
         :host {
-            width: 60px;
         }
 
         :host .layout {
-            /*max-width:;*/
         }
 
         :host([position="vertical"]) .menu-fab-button {

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -48,7 +48,7 @@
         }
 
         :host .layout {
-            max-width:;
+            /*max-width:;*/
         }
 
         :host([position="vertical"]) .menu-fab-button {

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -44,7 +44,7 @@
 <dom-module id="paper-fab-menu">
     <style is="custom-style">
         :host {
-            width : 60px;
+            width: 60px;
         }
 
         :host .layout {
@@ -52,28 +52,28 @@
         }
 
         :host([position="vertical"]) .menu-fab-button {
-            padding-top : 7px;
+            padding-top: 7px;
         }
         :host([position="vertical reversed"]) .menu-fab-button {
-            padding-bottom : 7px;
+            padding-bottom: 7px;
         }
         :host([position="horizontal"]) .menu-fab-button {
-            padding-left : 7px;
+            padding-left: 7px;
         }
         :host([position="horizontal reversed"]) .menu-fab-button {
-            padding-right : 7px;
+            padding-right: 7px;
         }
         :host-context([dir="rtl"]) :host([position="horizontal"]) .menu-fab-button,
         :host-context([dir="rtl"])[position="horizontal"] .menu-fab-button, /* Polymer workaround */
         :host([dir="rtl"][position="horizontal"]) .menu-fab-button {
-            padding-left : 0;
-            padding-right : 7px;
+            padding-left: 0;
+            padding-right: 7px;
         }
         :host-context([dir="rtl"]) :host([position="horizontal reversed"]) .menu-fab-button,
         :host-context([dir="rtl"])[position="horizontal reversed"] .menu-fab-button, /* Polymer workaround */
         :host([dir="rtl"][position="horizontal reversed"]) .menu-fab-button {
-            padding-right : 0;
-            padding-left : 7px;
+            padding-right: 0;
+            padding-left: 7px;
         }
 
         :host .menu-items ::content a {
@@ -86,23 +86,23 @@
         }
 
         :host paper-fab ::content iron-icon {
-            transition : 200ms all;
+            transition: 200ms all;
         }
 
         :host .menu-fab-button[open] paper-fab ::content iron-icon {
-            transform : rotate(45deg);
+            transform: rotate(45deg);
         }
 
         :host .menu-items {
-            order : 1;
+            order: 1;
         }
 
         :host .menu-fab-button {
-            order : 2;
+            order: 2;
         }
 
         :host .menu-items[open] ::content .menu-item {
-            transform : scale(1);
+            transform: scale(1);
         }
 
         :host .menu-items ::content paper-fab-menu-item:nth-child(1) .menu-item, :host .menu-items ::content a:nth-child(1) .menu-item {
@@ -129,15 +129,14 @@
             transition-delay: 0ms;
         }
 
-        :host .menu-items ::content paper-fab-menu-item .menu-item, :host .menu-items ::content a .menu-item
-        {
+        :host .menu-items ::content paper-fab-menu-item .menu-item, :host .menu-items ::content a .menu-item {
              transition: 100ms all;
         }
 
         /*REVERSED-STYLE-START*/
 
         :host .menu-items.reversed {
-            order : 3;
+            order: 3;
         }
 
         :host .menu-items.reversed ::content paper-fab-menu-item:nth-child(1) .menu-item, :host .menu-items.reversed ::content a:nth-child(1) .menu-item {
@@ -167,68 +166,72 @@
         /*REVERSED-STYLE-END*/
 
         :host paper-fab {
-            transform : scale(0);
-            animation : 300ms scale 300ms 1 forwards alternate cubic-bezier(0.165, 0.84, 0.44, 1);
+            transform: scale(0);
+            animation: 300ms scale 300ms 1 forwards alternate cubic-bezier(0.165, 0.84, 0.44, 1);
         }
 
         :host .menu-items:not([open]) {
-            animation : 0s delayed-disappearance 300ms 1 forwards;
+            animation: 0s delayed-disappearance 300ms 1 forwards;
         }
 
         @keyframes scale {
             0% {
-                transform         : scale(0);
-                -webkit-transform : scale(0);
+                transform        : scale(0);
+                -webkit-transform: scale(0);
             }
             100% {
-                transform         : scale(1.0);
-                -webkit-transform : scale(1.0);
+                transform        : scale(1.0);
+                -webkit-transform: scale(1.0);
             }
         }
 
         @keyframes delayed-disappearance {
-            from { height: auto; }
-            to   { height: 0;    }
+            from {
+                height: auto;
+            }
+            to   {
+                height: 0;
+            }
         }
     </style>
     <template>
-        <div class$="layout {{position}}">
+        <div class$="layout {{ position }}">
             <div open$="{{ show }}" id="mainFab" class="menu-fab-button layout vertical self-center">
                 <paper-fab id="paperFab" icon="{{ icon }}"></paper-fab>
             </div>
-            <div open$="{{ show }}" id="mainItems" class$="menu-items flex layout {{position}} self-center">
+            <div open$="{{ show }}" id="mainItems" class$="menu-items flex layout {{ position }} self-center">
                 <content select="a, paper-fab-menu-item"></content>
             </div>
         </div>
     </template>
     <script>
         Polymer({
-            is         : 'paper-fab-menu',
-            properties : {
-                position : {
-                    value : 'vertical' // ALLOWED: 'vertical', 'horizontal', 'vertical reversed', 'horizontal reversed'
+            is: 'paper-fab-menu',
+            properties: {
+                position: {
+                    value: 'vertical' // ALLOWED: 'vertical', 'horizontal', 'vertical reversed', 'horizontal reversed'
                 },
-                show     : {
-                    value : false
+                show: {
+                    value: false
                 },
                 color: {
                     type: String // any color you would like to be a main paper-fab
                 }
             },
-            listeners  : {
-                'mainFab.mouseover'   : 'open',
-                'mainFab.mouseout'    : 'close',
-                'mainItems.mouseover' : 'open',
-                'mainItems.mouseout'  : 'close'
+            listeners: {
+                'mainFab.mouseover':    'open',
+                'mainFab.mouseout':     'close',
+                'mainItems.mouseover':  'open',
+                'mainItems.mouseout':   'close'
             },
-            ready: function () {
+            ready: function() {
                 if(this.color)
                     this.$.paperFab.style.backgroundColor = this.color;
             },
-            open       : function() {
+            open: function() {
                 this.show = true;
             },
-            close      : function() {
+            close: function() {
                 this.show = false;
             }
         })

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -188,9 +188,11 @@
         @keyframes delayed-disappearance {
             from {
                 height: auto;
+                width: auto;
             }
             to   {
                 height: 0;
+                width: 0;
             }
         }
     </style>

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -93,6 +93,10 @@
 
         :host .menu-items {
             order: 1;
+            /* This prevents the browser window's scroll bar to sometimes appear
+             * when the menu is closed.
+             */
+            overflow: hidden;
         }
 
         :host .menu-fab-button {

--- a/paper-fab-menu.html
+++ b/paper-fab-menu.html
@@ -7,10 +7,10 @@
 **********
 *
 *   *** PAPER FAB MENU ***
-*   
+*
 *   This floating action button is using the Material Design concept of expandable
 *   Paper Fab Button and using the Polymer components to make the concept happen.
-*   
+*
 *   *** EXAMPLE - without links ***
 *   <paper-fab-menu color="teal" icon="add" position="vertical">
 *        <paper-fab-menu-item color="teal" label="Favorites" icon="star" ></paper-fab-menu-item>
@@ -23,13 +23,13 @@
 *   <paper-fab-menu color="red" icon="add" position="horizontal">
 *        <a href="#/favorites">
 *            <paper-fab-menu-item color="red" label="Favorites" icon="star" ></paper-fab-menu-item>
-*        </a>    
+*        </a>
 *        <a href="#/favorites">
 *            <paper-fab-menu-item color="red" label="Favorites" icon="star" ></paper-fab-menu-item>
-*        </a>  
+*        </a>
 *        <a href="#/favorites">
 *            <paper-fab-menu-item color="red" label="Favorites" icon="star" ></paper-fab-menu-item>
-*        </a>  
+*        </a>
 *   </paper-fab-menu>
 *
 ********** -->
@@ -171,6 +171,10 @@
             animation : 300ms scale 300ms 1 forwards alternate cubic-bezier(0.165, 0.84, 0.44, 1);
         }
 
+        :host .menu-items:not([open]) {
+            animation : 0s delayed-disappearance 300ms 1 forwards;
+        }
+
         @keyframes scale {
             0% {
                 transform         : scale(0);
@@ -180,6 +184,11 @@
                 transform         : scale(1.0);
                 -webkit-transform : scale(1.0);
             }
+        }
+
+        @keyframes delayed-disappearance {
+            from { height: auto; }
+            to   { height: 0;    }
         }
     </style>
     <template>


### PR DESCRIPTION
Even though the paper-fab-menu-item elements would be hidden, the div#mainItems itself would remain as a transparent block, taking mouse and touch events. This caused unintuitive behaviour, especially on touch devices where you need to drag the element underneath to scroll a menu or list; starting the drag inside the div#mainItems would prevent the scrolling.

The changes made also makes it so that one can use a more intuitive "right" offset for absolute and fixed positioning, as demonstrated by the change to line number 57 of the demo.html file.

The commits also improve coding style consistency across the three source files.

![the transparent block what blocks e.g. scrolling](https://cloud.githubusercontent.com/assets/1936058/19055873/8067c75e-89c6-11e6-9a25-96c3bc6d2a1c.png)
